### PR TITLE
quick fix for app/templates in addon projects

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ module.exports = {
     let checker = new VersionChecker(this);
     checker.for('ember-cli', 'npm').assertAbove('2.4.1');
 
-    if (type === 'templates') {
+    if (type === 'templates' || type === 'app') {
       let ui = this.ui;
       let mockConsole = {
         log(data) {


### PR DESCRIPTION
@Turbo87 we don't send a tempaltes tree down for `app/` when in an addon project. we do send down an unfiltered app tree though. we definately need to fix this in ember-cli but i think it involves a much larger conversation.

this temp is safe, because the broccoli plugin extends broccoli-filter `TemplateLinter.prototype.extensions = ['hbs', 'handlebars'];`