### PR TITLE
fixes build warning for internationalized projects

### DIFF
--- a/broccoli-template-linter.js
+++ b/broccoli-template-linter.js
@@ -129,7 +129,7 @@ TemplateLinter.prototype.postProcess = function(results) {
 };
 
 TemplateLinter.prototype.issueLocalizationWarningIfNeeded = function() {
-  if ('no-bare-strings' in this.linter.config.rules) {
+  if ('no-bare-strings' in this.linter.config.loadedRules) {
     return;
   }
 


### PR DESCRIPTION
* [x] fixes warning if no-bare-strings rule doesn't exist in an internationalized project

closes https://github.com/ember-template-lint/ember-cli-template-lint/issues/406