### PR TITLE
Support usage inside parallel babel inside inline-hbs

### DIFF
--- a/lib/plugins/remove-configuration-html-comments.js
+++ b/lib/plugins/remove-configuration-html-comments.js
@@ -29,5 +29,13 @@ module.exports = function() {
     return ast;
   };
 
+  RemoveConfigurationHtmlCommentsPlugin.parallelBabel = {
+    requireFile: __filename,
+    buildUsing: 'self',
+  };
+
   return RemoveConfigurationHtmlCommentsPlugin;
 };
+
+module.exports.self = function(){ return module.exports(); };
+


### PR DESCRIPTION
Fixes #444.

ember-cli-htmlbars-inline-precompile becomes parallelizable if all the AST transforms inside it are parallelizable. The protocol it supports is *nearly* the same as the one used by broccoli-babel-transpiler itself, but not quite.

In particular, the special key is named `parallelBabel` instead of `_parallelBabel`, the `buildUsing` property is mandatory, and there is no recursion to look for deeper unserializable things.