### PR TITLE
Drop NodeJs 6, 8, 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "10"
+  - "12"
 
 addons:
   chrome: stable
@@ -42,12 +42,12 @@ jobs:
     # - run tests without pinned dependencies to catch issues with new versions
 
     - stage: additional tests
-      name: "Node 6 Tests"
-      node_js: 6
+      name: "Node 10 Tests"
+      node_js: 10
       script:
         - yarn test:node
-    - name: "Node 8 Tests"
-      node_js: 8
+    - name: "Node 13 Tests"
+      node_js: 13
       script:
         - yarn test:node
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "qunit-dom": "^0.8.0"
   },
   "engines": {
-    "node": "6.* || 8.* || >= 10.*"
+    "node": "10.* || >=12.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
Is it still recomended to use ember-cli-template-lint @rwjblue ? It is still shipped with ember-cli's default blueprints. So I would assume a yes. Plus, I haven't found any RFC to deprecate usage of ember-cli-eslint and ember-cli-template-lint. But would this change require an RFC at all?

In the meantime, let's drop Node 6 / 8 / 11, it will allow dependabot to merge a few PRs. And ember-cli-template-lint is still in a beta cycle, so no major bump would be required?