### PR TITLE
Update blueprint to use `octane` config

### DIFF
--- a/blueprints/ember-cli-template-lint/recommended-files/.template-lintrc.js
+++ b/blueprints/ember-cli-template-lint/recommended-files/.template-lintrc.js
@@ -2,5 +2,5 @@
 'use strict';
 
 module.exports = {
-  extends: 'recommended'
+  extends: 'octane'
 };

--- a/blueprints/ember-cli-template-lint/recommended-with-bare-strings-files/.template-lintrc.js
+++ b/blueprints/ember-cli-template-lint/recommended-with-bare-strings-files/.template-lintrc.js
@@ -2,7 +2,7 @@
 'use strict';
 
 module.exports = {
-  extends: 'recommended',
+  extends: 'octane'
 
   rules: {
     'no-bare-strings': true

--- a/node-tests/blueprints/ember-cli-template-lint-test.js
+++ b/node-tests/blueprints/ember-cli-template-lint-test.js
@@ -28,7 +28,7 @@ describe('Acceptance: ember generate and destroy ember-cli-template-lint', funct
     yield emberNew();
     yield emberGenerate(args);
 
-    expect(file('.template-lintrc.js')).to.contain('extends: \'recommended\'');
+    expect(file('.template-lintrc.js')).to.contain('extends: \'octane\'');
   }));
 
   it('ember-cli-template-lint with localization framework', co.wrap(function *() {
@@ -38,7 +38,7 @@ describe('Acceptance: ember generate and destroy ember-cli-template-lint', funct
     yield emberNew();
     yield emberGenerate(args);
 
-    expect(file('.template-lintrc.js')).to.contain('extends: \'recommended\'');
+    expect(file('.template-lintrc.js')).to.contain('extends: \'octane\'');
     expect(file('.template-lintrc.js')).to.contain('\'no-bare-strings\': true');
   }));
 });


### PR DESCRIPTION
This set is already used in ember-cli blueprints.

EDIT: I have removed the `breaking` label, as it is a change affecting only the blueprints 😄