### PR TITLE
Allow ast-plugin to run in parallel

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,6 +5,9 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
     // Add options here
+    'ember-cli-babel': {
+      throwUnlessParallelizable: true
+    }
   });
 
   /*

--- a/index.js
+++ b/index.js
@@ -64,14 +64,26 @@ module.exports = {
   },
 
   setupPreprocessorRegistry(type, registry) {
+    const plugin = this._buildPlugin();
+
+    plugin.parallelBabel = {
+      requireFile: __filename,
+      buildUsing: '_buildPlugin',
+      params: {}
+    };
+
+    registry.add('htmlbars-ast-plugin', plugin);
+  },
+
+  _buildPlugin() {
     let RemoveConfigurationHtmlComments = require('./lib/plugins/remove-configuration-html-comments');
 
-    registry.add('htmlbars-ast-plugin', {
+    return {
       name: 'remove-configuration-html-comments',
       plugin: RemoveConfigurationHtmlComments(),
       baseDir() {
         return __dirname;
       }
-    });
+    };
   }
 };


### PR DESCRIPTION
Fixes #512 

I discovered this while investigating why parallel babel builds were not working in my app. While I don't use ember-cli-template-lint personally, it's in the ember-cli blueprint so all brand new ember apps are prevented from running in parallel. I already did similar over at https://github.com/pzuraq/ember-simple-set-helper/pull/3